### PR TITLE
Add support for macOS Sonoma 14.

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -1339,7 +1339,7 @@
 			<key>SystemMemoryStatus</key>
 			<string>Auto</string>
 			<key>SystemProductName</key>
-			<string>MacBookPro14,2</string>
+			<string>MacBookPro15,2</string>
 			<key>SystemSerialNumber</key>
 			<string></string>
 			<key>SystemUUID</key>

--- a/EFI/OC/Kexts/USBMap.kext/Contents/Info.plist
+++ b/EFI/OC/Kexts/USBMap.kext/Contents/Info.plist
@@ -22,7 +22,7 @@
 	<string>1.0</string>
 	<key>IOKitPersonalities</key>
 	<dict>
-		<key>MacBookPro14,2-XHC</key>
+		<key>MacBookPro15,2-XHC</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.apple.driver.AppleUSBHostMergeProperties</string>
@@ -105,7 +105,7 @@
 				</dict>
 			</dict>
 			<key>model</key>
-			<string>MacBookPro14,2</string>
+			<string>MacBookPro15,2</string>
 		</dict>
 	</dict>
 	<key>OSBundleRequired</key>

--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@
 - macOS Sonoma 14 Beta
 - OpenCore r0.9.3
 
-## 🌾 macOS Sonoma 14.0 Beta
-1. Change SMBIOS to `MacBookPro15,2` model in Config.plist
-2. Modify SMBIOS to `MacBookPro15,2` model in Info.plist of USBMap.kext
-
 ## ❄️ ACPI SSDT Hot Patches
 | No. | SSDT Name | ACPI Rename Required | ACPI Patch Type | OEM DSDT Override |
 |:-:|:-:|:-:|:-:|:-:|


### PR DESCRIPTION
- [X] Change SMBIOS to `MacBookPro15,2` model in Config.plist
- [X] Modify SMBIOS to `MacBookPro15,2` model in Info.plist of USBMap.kext
- [X] Update README.md